### PR TITLE
Fix mobile Safari overscroll showing black on landing and CV pages

### DIFF
--- a/app/src/app/cv/page.tsx
+++ b/app/src/app/cv/page.tsx
@@ -314,6 +314,16 @@ export default function CVPage() {
     setLoaded(true);
   }, []);
 
+  // Set the html background to cream so mobile Safari's overscroll area
+  // matches the page instead of showing the default dark root background.
+  useEffect(() => {
+    const prev = document.documentElement.style.backgroundColor;
+    document.documentElement.style.backgroundColor = "#f3f1ea";
+    return () => {
+      document.documentElement.style.backgroundColor = prev;
+    };
+  }, []);
+
   return (
     <>
       <style>{cvStyles}</style>

--- a/app/src/components/LandingPage.tsx
+++ b/app/src/components/LandingPage.tsx
@@ -70,6 +70,16 @@ export default function LandingPage() {
   const [cursorEnabled, setCursorEnabled] = useState(false);
   const shouldReduce = useReducedMotion();
 
+  // Set the html background to cream so mobile Safari's overscroll area
+  // matches the page instead of showing the default dark root background.
+  useEffect(() => {
+    const prev = document.documentElement.style.backgroundColor;
+    document.documentElement.style.backgroundColor = "#f3f1ea";
+    return () => {
+      document.documentElement.style.backgroundColor = prev;
+    };
+  }, []);
+
   // Detect mobile to push the name's hidden position further off-screen.
   // On small screens the text is smaller, so "108%" isn't enough to hide it
   // below the viewport edge — use a much larger translate instead.


### PR DESCRIPTION
Set html background-color to cream on mount so the rubber-band overscroll
area in mobile Safari matches the page content instead of the dark root
background. Restored on unmount so other pages are unaffected.

https://claude.ai/code/session_0177A62piDP26NkM7vGsgp6i