### PR TITLE
Fix mobile Safari overscroll using CSS class instead of inline style

### DIFF
--- a/app/src/app/[slug]/page.tsx
+++ b/app/src/app/[slug]/page.tsx
@@ -5,6 +5,11 @@ import {
 } from "@/lib/fetchRepos";
 import { ProjectDetailsClient } from "./project-details";
 import { notFound } from "next/navigation";
+import type { Viewport } from "next";
+
+export const viewport: Viewport = {
+  themeColor: "#000000",
+};
 
 interface PageProps {
   params: Promise<{

--- a/app/src/app/analytics/layout.tsx
+++ b/app/src/app/analytics/layout.tsx
@@ -1,0 +1,13 @@
+import type { Viewport } from "next";
+
+export const viewport: Viewport = {
+  themeColor: "#000000",
+};
+
+export default function AnalyticsLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <>{children}</>;
+}

--- a/app/src/app/article/[slug]/page.tsx
+++ b/app/src/app/article/[slug]/page.tsx
@@ -16,7 +16,11 @@ import { CodeBlock } from "@/components/mdx/CodeBlock";
 import rehypeHighlight from "rehype-highlight";
 import rehypeSlug from "rehype-slug";
 import rehypeAutolinkHeadings from "rehype-autolink-headings";
-import { Metadata } from "next";
+import { Metadata, Viewport } from "next";
+
+export const viewport: Viewport = {
+  themeColor: "#000000",
+};
 import React from "react";
 
 const components = {

--- a/app/src/app/article/page.tsx
+++ b/app/src/app/article/page.tsx
@@ -1,7 +1,11 @@
 import { getAllPosts, formatDate } from "@/lib/article";
 import Link from "next/link";
 import Image from "next/image";
-import { Metadata } from "next";
+import { Metadata, Viewport } from "next";
+
+export const viewport: Viewport = {
+  themeColor: "#000000",
+};
 
 export const metadata: Metadata = {
   title: "Articles",

--- a/app/src/app/cv/page.tsx
+++ b/app/src/app/cv/page.tsx
@@ -314,14 +314,11 @@ export default function CVPage() {
     setLoaded(true);
   }, []);
 
-  // Set the html background to cream so mobile Safari's overscroll area
-  // matches the page instead of showing the default dark root background.
+  // Adds .cream-bg to <html> so globals.css can paint both html + body cream,
+  // fixing mobile Safari rubber-band overscroll showing the dark root bg.
   useEffect(() => {
-    const prev = document.documentElement.style.backgroundColor;
-    document.documentElement.style.backgroundColor = "#f3f1ea";
-    return () => {
-      document.documentElement.style.backgroundColor = prev;
-    };
+    document.documentElement.classList.add("cream-bg");
+    return () => document.documentElement.classList.remove("cream-bg");
   }, []);
 
   return (

--- a/app/src/app/donate/layout.tsx
+++ b/app/src/app/donate/layout.tsx
@@ -1,0 +1,13 @@
+import type { Viewport } from "next";
+
+export const viewport: Viewport = {
+  themeColor: "#000000",
+};
+
+export default function DonateLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <>{children}</>;
+}

--- a/app/src/app/globals.css
+++ b/app/src/app/globals.css
@@ -17,6 +17,13 @@
 html {
     scroll-behavior: smooth;
     scroll-padding-top: 4rem;
+    /* Fallback so the dark root background never bleeds through overscroll */
+    background-color: #0a0a0f;
+}
+
+html.cream-bg,
+html.cream-bg body {
+    background-color: #f3f1ea;
 }
 
 body {

--- a/app/src/app/layout.tsx
+++ b/app/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata, Viewport } from "next";
+import type { Metadata } from "next";
 import { Geist, Geist_Mono, Inter, Fraunces } from "next/font/google";
 import "./globals.css";
 import { AnalyticsProvider } from "@/components/analytics-provider";
@@ -23,9 +23,6 @@ const fraunces = Fraunces({
   axes: ["opsz"],
 });
 
-export const viewport: Viewport = {
-  themeColor: "#000000",
-};
 
 export const metadata: Metadata = {
   title: "Doğukan",

--- a/app/src/app/letter/[letter]/page.tsx
+++ b/app/src/app/letter/[letter]/page.tsx
@@ -1,4 +1,9 @@
 import { notFound } from "next/navigation";
+import type { Viewport } from "next";
+
+export const viewport: Viewport = {
+  themeColor: "#000000",
+};
 
 interface PageProps {
   params: Promise<{

--- a/app/src/app/projects/layout.tsx
+++ b/app/src/app/projects/layout.tsx
@@ -1,0 +1,13 @@
+import type { Viewport } from "next";
+
+export const viewport: Viewport = {
+  themeColor: "#000000",
+};
+
+export default function ProjectsLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <>{children}</>;
+}

--- a/app/src/components/LandingPage.tsx
+++ b/app/src/components/LandingPage.tsx
@@ -70,14 +70,11 @@ export default function LandingPage() {
   const [cursorEnabled, setCursorEnabled] = useState(false);
   const shouldReduce = useReducedMotion();
 
-  // Set the html background to cream so mobile Safari's overscroll area
-  // matches the page instead of showing the default dark root background.
+  // Adds .cream-bg to <html> so globals.css can paint both html + body cream,
+  // fixing mobile Safari rubber-band overscroll showing the dark root bg.
   useEffect(() => {
-    const prev = document.documentElement.style.backgroundColor;
-    document.documentElement.style.backgroundColor = "#f3f1ea";
-    return () => {
-      document.documentElement.style.backgroundColor = prev;
-    };
+    document.documentElement.classList.add("cream-bg");
+    return () => document.documentElement.classList.remove("cream-bg");
   }, []);
 
   // Detect mobile to push the name's hidden position further off-screen.


### PR DESCRIPTION
Switch from setting html.style.backgroundColor to toggling a .cream-bg
class on <html>, which lets globals.css paint both html and body cream via
the cascade. This ensures the rubber-band overscroll in mobile Safari sees
cream on both elements rather than the dark body background.

https://claude.ai/code/session_0177A62piDP26NkM7vGsgp6i