### PR TITLE
Add slide-down entrance animation to navbar on page load

### DIFF
--- a/app/src/components/LandingPage.tsx
+++ b/app/src/components/LandingPage.tsx
@@ -115,6 +115,14 @@ export default function LandingPage() {
     },
   };
 
+  const navVariants = {
+    hidden: { y: "-100%" },
+    visible: {
+      y: "0%",
+      transition: { duration: 1.0, ease: expo, delay: 0.25 },
+    },
+  };
+
   return (
     <main
       className={`relative w-full min-h-screen overflow-x-hidden${cursorEnabled ? " cursor-none" : ""}`}
@@ -126,7 +134,7 @@ export default function LandingPage() {
       <Cursor onEnable={setCursorEnabled} />
 
       {/* ── Nav ─────────────────────────────────────────────────────────── */}
-      <nav
+      <motion.nav
         aria-label="primary navigation"
         className="fixed top-0 left-0 right-0 z-50 flex flex-wrap items-center justify-between px-6 py-4 md:py-5 md:px-10"
         style={{
@@ -134,6 +142,9 @@ export default function LandingPage() {
           backdropFilter: "blur(12px)",
           WebkitBackdropFilter: "blur(12px)",
         }}
+        variants={navVariants}
+        initial={shouldReduce ? "visible" : "hidden"}
+        animate="visible"
       >
         <div className="flex items-center gap-4">
           <span
@@ -164,7 +175,7 @@ export default function LandingPage() {
             sensity.ai
           </UnderlineLink>
         </div>
-      </nav>
+      </motion.nav>
 
       {/* ── Hero ─────────────────────────────────────────────────────────── */}
       <section className="relative h-[100svh] flex flex-col items-center justify-center">


### PR DESCRIPTION
Mirrors the existing hero animations: the portrait reveals downward and the
name slides up from below, so the navbar now slides in from the top using the
same expo easing and timing (1.0s, 0.25s delay) — the reverse direction.

Respects the prefers-reduced-motion setting via shouldReduce.

https://claude.ai/code/session_01X83ZBwoy32muVyLggvB7eF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The landing page navigation now displays a smooth entrance animation when the page loads, transitioning smoothly into view for a refined user experience.
  * Animation behavior intelligently adapts based on user motion preferences, maintaining accessibility for all visitors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->