### PR TITLE
Stagger landing animations into two waves and slow them down

### DIFF
--- a/app/src/components/LandingPage.tsx
+++ b/app/src/components/LandingPage.tsx
@@ -86,11 +86,12 @@ export default function LandingPage() {
   // Cubic bezier typed as a tuple — required by framer-motion's Easing type
   const expo = [0.16, 1, 0.3, 1] as [number, number, number, number];
 
+  // Portrait and nav links both start 0.5 s after page load.
   const portraitVariants = {
     hidden: { clipPath: "inset(100% 0% 0% 0%)" },
     visible: {
       clipPath: "inset(0% 0% 0% 0%)",
-      transition: { duration: 1.1, ease: expo },
+      transition: { duration: 1.4, ease: expo, delay: 0.5 },
     },
   };
 
@@ -98,11 +99,12 @@ export default function LandingPage() {
   // The clip lives on the wrapper (below) so it can open its top beyond
   // the wrapper’s own box — giving the accents room without a state toggle.
   // On mobile we use a larger translate so the text starts fully off-screen.
+  // Starts immediately with the navbar (delay: 0).
   const nameVariants = {
     hidden: { y: isMobile ? "250%" : "108%" },
     visible: {
       y: "0%",
-      transition: { duration: 1.0, ease: expo, delay: 0.25 },
+      transition: { duration: 1.3, ease: expo, delay: 0 },
     },
   };
 
@@ -115,11 +117,22 @@ export default function LandingPage() {
     },
   };
 
+  // Navbar slides in from the top immediately on load (same time as hero name).
   const navVariants = {
     hidden: { y: "-100%" },
     visible: {
       y: "0%",
-      transition: { duration: 1.0, ease: expo, delay: 0.25 },
+      transition: { duration: 1.3, ease: expo, delay: 0 },
+    },
+  };
+
+  // Nav links (about / resume) fade in 0.5 s after load, same wave as the portrait.
+  const navLinksVariants = {
+    hidden: { opacity: 0, y: -10 },
+    visible: {
+      opacity: 1,
+      y: 0,
+      transition: { duration: 0.9, ease: expo, delay: 0.5 },
     },
   };
 
@@ -161,10 +174,15 @@ export default function LandingPage() {
             <UnderlineLink href="https://sensity.ai">sensity.ai</UnderlineLink>
           </span>
         </div>
-        <div className="flex items-center gap-6">
+        <motion.div
+          className="flex items-center gap-6"
+          variants={navLinksVariants}
+          initial={shouldReduce ? "visible" : "hidden"}
+          animate="visible"
+        >
           <UnderlineLink href="#about">about</UnderlineLink>
           <UnderlineLink href="/cv">resume</UnderlineLink>
-        </div>
+        </motion.div>
         {/* Mobile-only role subtitle — sits below the first row */}
         <div
           className="w-full mt-1 md:hidden text-xs tracking-wide leading-relaxed"
@@ -219,7 +237,7 @@ export default function LandingPage() {
               : { clipPath: "inset(0px -600px -40px -600px)" }
           }
           animate={{ clipPath: "inset(-30px -600px -40px -600px)" }}
-          transition={{ duration: 1.25, ease: "linear" }}
+          transition={{ duration: 1.6, ease: "linear" }}
           aria-hidden
         >
           <motion.h1

--- a/app/src/components/LandingPage.tsx
+++ b/app/src/components/LandingPage.tsx
@@ -83,10 +83,13 @@ export default function LandingPage() {
     return () => mql.removeEventListener("change", handler);
   }, []);
 
-  // Cubic bezier typed as a tuple — required by framer-motion's Easing type
+  // Cubic bezier typed as a tuple — required by framer-motion’s Easing type
   const expo = [0.16, 1, 0.3, 1] as [number, number, number, number];
 
-  // Portrait and nav links both start 0.5 s after page load.
+  // Overdamped spring for Y-axis entrances — natural deceleration, no bounce.
+  const spring = { type: "spring" as const, stiffness: 100, damping: 22 };
+
+  // Portrait: clipPath reveal uses duration-based easing to avoid spring overshoot on clip edges.
   const portraitVariants = {
     hidden: { clipPath: "inset(100% 0% 0% 0%)" },
     visible: {
@@ -95,43 +98,40 @@ export default function LandingPage() {
     },
   };
 
-  // y-translate on the h1 gives the physical rise feel.
-  // The clip lives on the wrapper (below) so it can open its top beyond
-  // the wrapper’s own box — giving the accents room without a state toggle.
-  // On mobile we use a larger translate so the text starts fully off-screen.
-  // Starts immediately with the navbar (delay: 0).
+  // Hero name rises from below with spring physics for a physical, weighted feel.
+  // On mobile we use a larger initial offset so the text starts fully off-screen.
   const nameVariants = {
     hidden: { y: isMobile ? "250%" : "108%" },
     visible: {
       y: "0%",
-      transition: { duration: 1.3, ease: expo, delay: 0 },
+      transition: { ...spring, delay: 0 },
     },
   };
 
+  // Scroll-triggered intro — expo easing consistent with all other animations.
   const introVariants = {
     hidden: { opacity: 0, y: 28 },
     visible: {
       opacity: 1,
       y: 0,
-      transition: { duration: 0.9, ease: "easeOut" as const },
+      transition: { duration: 0.9, ease: expo },
     },
   };
 
-  // Navbar slides in from the top immediately on load (same time as hero name).
+  // Navbar slides in from the top with spring physics, same wave as the hero name.
   const navVariants = {
     hidden: { y: "-100%" },
     visible: {
       y: "0%",
-      transition: { duration: 1.3, ease: expo, delay: 0 },
+      transition: { ...spring, delay: 0 },
     },
   };
 
-  // Nav links (about / resume) fade in 0.5 s after load, same wave as the portrait.
+  // Nav links: opacity-only fade — the nav slide already provides directional context.
   const navLinksVariants = {
-    hidden: { opacity: 0, y: -10 },
+    hidden: { opacity: 0 },
     visible: {
       opacity: 1,
-      y: 0,
       transition: { duration: 0.9, ease: expo, delay: 0.5 },
     },
   };
@@ -237,7 +237,7 @@ export default function LandingPage() {
               : { clipPath: "inset(0px -600px -40px -600px)" }
           }
           animate={{ clipPath: "inset(-30px -600px -40px -600px)" }}
-          transition={{ duration: 1.6, ease: "linear" }}
+          transition={{ duration: 1.6, ease: expo }}
           aria-hidden
         >
           <motion.h1
@@ -262,6 +262,32 @@ export default function LandingPage() {
             Doğukan Ürker
           </motion.h1>
         </motion.div>
+
+        {/* Scroll cue — animated fill/drain line on the left, desktop only */}
+        {!shouldReduce && (
+          <motion.div
+            className="absolute left-6 md:left-10 bottom-12 hidden sm:block pointer-events-none select-none"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ delay: 1.8, duration: 0.8, ease: "easeOut" }}
+            aria-hidden
+          >
+            <div className="w-px h-12 overflow-hidden">
+              <motion.div
+                className="w-full h-full"
+                style={{ backgroundColor: "var(--brand-dim)" }}
+                animate={{ y: ["-100%", "0%", "0%", "100%"] }}
+                transition={{
+                  duration: 2.2,
+                  times: [0, 0.35, 0.65, 1],
+                  repeat: Infinity,
+                  ease: "easeInOut",
+                  repeatDelay: 0.5,
+                }}
+              />
+            </div>
+          </motion.div>
+        )}
       </section>
 
       {/* ── Intro ────────────────────────────────────────────────────────── */}

--- a/app/src/components/LandingPage.tsx
+++ b/app/src/components/LandingPage.tsx
@@ -319,10 +319,7 @@ export default function LandingPage() {
       {/* ── Intro ────────────────────────────────────────────────────────── */}
       <section
         className="relative z-10 min-h-screen flex items-center justify-center px-6 py-24"
-        style={{
-          backgroundColor: "var(--brand-cream)",
-          boxShadow: "0 -32px 80px 0 rgba(22, 20, 13, 0.07)",
-        }}
+        style={{ backgroundColor: "var(--brand-cream)" }}
       >
         {/* Offset anchor: 96 px into the section so clicking "about" in the nav
             scrolls past the ğ glyph that bleeds in from the hero above. */}
@@ -375,9 +372,9 @@ export default function LandingPage() {
 
       {/* ── Footer ───────────────────────────────────────────────────────── */}
       <motion.footer
-        className="flex flex-col items-center gap-3 pb-10 px-6
+        className="relative z-10 flex flex-col items-center gap-3 pb-10 px-6
           sm:flex-row sm:items-center sm:justify-between sm:px-10"
-        style={{ color: "var(--brand-muted)" }}
+        style={{ color: "var(--brand-muted)", backgroundColor: "var(--brand-cream)" }}
         variants={footerVariants}
         initial={shouldReduce ? "visible" : "hidden"}
         whileInView="visible"

--- a/app/src/components/LandingPage.tsx
+++ b/app/src/components/LandingPage.tsx
@@ -83,6 +83,19 @@ export default function LandingPage() {
     return () => mql.removeEventListener("change", handler);
   }, []);
 
+  // Scroll cue: appears after 1.8 s, fades out when scrolled, fades back in on return.
+  const [cueVisible, setCueVisible] = useState(false);
+  const [scrolled, setScrolled] = useState(false);
+  useEffect(() => {
+    const timer = setTimeout(() => setCueVisible(true), 1800);
+    const onScroll = () => setScrolled(window.scrollY > 60);
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => {
+      clearTimeout(timer);
+      window.removeEventListener("scroll", onScroll);
+    };
+  }, []);
+
   // Cubic bezier typed as a tuple — required by framer-motion’s Easing type
   const expo = [0.16, 1, 0.3, 1] as [number, number, number, number];
 
@@ -133,6 +146,20 @@ export default function LandingPage() {
     visible: {
       opacity: 1,
       transition: { duration: 0.9, ease: expo, delay: 0.5 },
+    },
+  };
+
+  // Footer: stagger location + each social link in from below as the section enters view.
+  const footerVariants = {
+    hidden: {},
+    visible: { transition: { staggerChildren: 0.08 } },
+  };
+  const footerItemVariants = {
+    hidden: { opacity: 0, y: 16 },
+    visible: {
+      opacity: 1,
+      y: 0,
+      transition: { duration: 0.65, ease: expo },
     },
   };
 
@@ -263,13 +290,12 @@ export default function LandingPage() {
           </motion.h1>
         </motion.div>
 
-        {/* Scroll cue — animated fill/drain line on the left, desktop only */}
+        {/* Scroll cue — fades in at 1.8 s, out when scrolled, back in on return */}
         {!shouldReduce && (
           <motion.div
             className="absolute left-6 md:left-10 bottom-12 hidden sm:block pointer-events-none select-none"
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            transition={{ delay: 1.8, duration: 0.8, ease: "easeOut" }}
+            animate={{ opacity: cueVisible && !scrolled ? 1 : 0 }}
+            transition={{ duration: 0.5, ease: "easeOut" }}
             aria-hidden
           >
             <div className="w-px h-12 overflow-hidden">
@@ -342,27 +368,33 @@ export default function LandingPage() {
       </section>
 
       {/* ── Footer ───────────────────────────────────────────────────────── */}
-      <footer
+      <motion.footer
         className="flex flex-col items-center gap-3 pb-10 px-6
           sm:flex-row sm:items-center sm:justify-between sm:px-10"
         style={{ color: "var(--brand-muted)" }}
+        variants={footerVariants}
+        initial={shouldReduce ? "visible" : "hidden"}
+        whileInView="visible"
+        viewport={{ once: true, margin: "-40px" }}
       >
-        <span className="text-sm">izmir, türkiye</span>
+        <motion.span className="text-sm" variants={footerItemVariants}>
+          izmir, türkiye
+        </motion.span>
         <nav aria-label="social links" className="flex items-center gap-5">
-          <UnderlineLink href="mailto:dogukanurker@icloud.me">
-            mail
-          </UnderlineLink>
-          <UnderlineLink href="https://github.com/dogukanurker">
-            github
-          </UnderlineLink>
-          <UnderlineLink href="https://twitter.com/dogukanurker">
-            twitter
-          </UnderlineLink>
-          <UnderlineLink href="https://linkedin.com/in/dogukanurker">
-            linkedin
-          </UnderlineLink>
+          <motion.span variants={footerItemVariants}>
+            <UnderlineLink href="mailto:dogukanurker@icloud.me">mail</UnderlineLink>
+          </motion.span>
+          <motion.span variants={footerItemVariants}>
+            <UnderlineLink href="https://github.com/dogukanurker">github</UnderlineLink>
+          </motion.span>
+          <motion.span variants={footerItemVariants}>
+            <UnderlineLink href="https://twitter.com/dogukanurker">twitter</UnderlineLink>
+          </motion.span>
+          <motion.span variants={footerItemVariants}>
+            <UnderlineLink href="https://linkedin.com/in/dogukanurker">linkedin</UnderlineLink>
+          </motion.span>
         </nav>
-      </footer>
+      </motion.footer>
     </main>
   );
 }

--- a/app/src/components/LandingPage.tsx
+++ b/app/src/components/LandingPage.tsx
@@ -378,7 +378,7 @@ export default function LandingPage() {
         variants={footerVariants}
         initial={shouldReduce ? "visible" : "hidden"}
         whileInView="visible"
-        viewport={{ once: true, margin: "-40px" }}
+        viewport={{ once: true, margin: "100px" }}
       >
         <motion.span className="text-sm" variants={footerItemVariants}>
           izmir, türkiye

--- a/app/src/components/LandingPage.tsx
+++ b/app/src/components/LandingPage.tsx
@@ -165,7 +165,7 @@ export default function LandingPage() {
 
   return (
     <main
-      className={`relative w-full min-h-screen overflow-x-clip${cursorEnabled ? " cursor-none" : ""}`}
+      className={`relative w-full min-h-screen overflow-x-hidden${cursorEnabled ? " cursor-none" : ""}`}
       style={{
         backgroundColor: "var(--brand-cream)",
         color: "var(--brand-ink)",
@@ -223,7 +223,7 @@ export default function LandingPage() {
       </motion.nav>
 
       {/* ── Hero ─────────────────────────────────────────────────────────── */}
-      <section className="sticky top-0 h-[100svh] flex flex-col items-center justify-center">
+      <section className="relative h-[100svh] flex flex-col items-center justify-center">
         {/* Portrait */}
         <div
           className="group relative z-10"
@@ -317,10 +317,7 @@ export default function LandingPage() {
       </section>
 
       {/* ── Intro ────────────────────────────────────────────────────────── */}
-      <section
-        className="relative z-10 min-h-screen flex items-center justify-center px-6 py-24"
-        style={{ backgroundColor: "var(--brand-cream)" }}
-      >
+      <section className="relative min-h-screen flex items-center justify-center px-6 py-24">
         {/* Offset anchor: 96 px into the section so clicking "about" in the nav
             scrolls past the ğ glyph that bleeds in from the hero above. */}
         <span id="about" className="absolute top-24" aria-hidden />
@@ -372,9 +369,9 @@ export default function LandingPage() {
 
       {/* ── Footer ───────────────────────────────────────────────────────── */}
       <motion.footer
-        className="relative z-10 flex flex-col items-center gap-3 pb-10 px-6
+        className="flex flex-col items-center gap-3 pb-10 px-6
           sm:flex-row sm:items-center sm:justify-between sm:px-10"
-        style={{ color: "var(--brand-muted)", backgroundColor: "var(--brand-cream)" }}
+        style={{ color: "var(--brand-muted)" }}
         variants={footerVariants}
         initial={shouldReduce ? "visible" : "hidden"}
         whileInView="visible"

--- a/app/src/components/LandingPage.tsx
+++ b/app/src/components/LandingPage.tsx
@@ -165,7 +165,7 @@ export default function LandingPage() {
 
   return (
     <main
-      className={`relative w-full min-h-screen overflow-x-hidden${cursorEnabled ? " cursor-none" : ""}`}
+      className={`relative w-full min-h-screen overflow-x-clip${cursorEnabled ? " cursor-none" : ""}`}
       style={{
         backgroundColor: "var(--brand-cream)",
         color: "var(--brand-ink)",
@@ -223,7 +223,7 @@ export default function LandingPage() {
       </motion.nav>
 
       {/* ── Hero ─────────────────────────────────────────────────────────── */}
-      <section className="relative h-[100svh] flex flex-col items-center justify-center">
+      <section className="sticky top-0 h-[100svh] flex flex-col items-center justify-center">
         {/* Portrait */}
         <div
           className="group relative z-10"
@@ -317,7 +317,13 @@ export default function LandingPage() {
       </section>
 
       {/* ── Intro ────────────────────────────────────────────────────────── */}
-      <section className="relative min-h-screen flex items-center justify-center px-6 py-24">
+      <section
+        className="relative z-10 min-h-screen flex items-center justify-center px-6 py-24"
+        style={{
+          backgroundColor: "var(--brand-cream)",
+          boxShadow: "0 -32px 80px 0 rgba(22, 20, 13, 0.07)",
+        }}
+      >
         {/* Offset anchor: 96 px into the section so clicking "about" in the nav
             scrolls past the ğ glyph that bleeds in from the hero above. */}
         <span id="about" className="absolute top-24" aria-hidden />


### PR DESCRIPTION
## Summary

- **Wave 1 (0 s):** Navbar slides down + big hero name rises — both start immediately on page load at the same time
- **Wave 2 (0.5 s):** Portrait reveals + about/resume nav links fade in — both start together half a second later
- **Slower durations:** navbar/name `1.0 → 1.3 s`, portrait `1.1 → 1.4 s`, name-clip mask `1.25 → 1.6 s`
- The about/resume links are now wrapped in their own `motion.div` so they animate independently from the navbar slide

## Test plan
- [ ] Load the page and confirm navbar + hero name start simultaneously at 0 s
- [ ] Confirm portrait + about/resume links appear together ~0.5 s after load
- [ ] Confirm all animations feel slightly slower/more deliberate than before
- [ ] Check `prefers-reduced-motion` still skips all animations

---
_Generated by [Claude Code](https://claude.ai/code/session_01X83ZBwoy32muVyLggvB7eF)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added scroll-driven visual cue to the landing page.
  * Enhanced navigation and footer with staggered entrance animations.

* **Style**
  * Updated landing page animation timing and easing transitions.
  * Adjusted hero section positioning for improved scrolling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->