### PR TITLE
redesign projects and project details pages in brand-aligned cream/ink aesthetic

### DIFF
--- a/app/src/app/[slug]/loading.tsx
+++ b/app/src/app/[slug]/loading.tsx
@@ -1,67 +1,16 @@
-import { Skeleton } from "@/components/ui/skeleton";
-import { Card, CardContent, CardHeader } from "@/components/ui/card";
-
 export default function Loading() {
   return (
-    <div className="container mx-auto px-4 py-6 md:py-10 space-y-6 md:space-y-8">
-      <div className="flex flex-col gap-4">
-        <div className="flex flex-col gap-2">
-          <div className="flex justify-between items-center">
-            <Skeleton className="h-10 w-32" />
-            <Skeleton className="h-10 w-24" />
-          </div>
-          <Skeleton className="h-12 w-64" />
-        </div>
-      </div>
-
-      <Card>
-        <CardHeader className="space-y-4">
-          <Skeleton className="h-6 w-3/4" />
-          <Skeleton className="h-10 w-40" />
-        </CardHeader>
-        <CardContent className="space-y-8">
-          <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
-            {[1, 2, 3].map((i) => (
-              <Card key={i} className="p-3 md:p-4">
-                <Skeleton className="h-6 w-24" />
-              </Card>
-            ))}
-          </div>
-
-          <div className="space-y-4">
-            <Skeleton className="h-6 w-32" />
-            <div className="space-y-3">
-              {[1, 2, 3, 4].map((i) => (
-                <div key={i} className="space-y-1">
-                  <div className="flex justify-between">
-                    <Skeleton className="h-4 w-20" />
-                    <Skeleton className="h-4 w-12" />
-                  </div>
-                  <Skeleton className="h-2 w-full" />
-                </div>
-              ))}
-            </div>
-          </div>
-
-          <div className="space-y-4">
-            <Skeleton className="h-6 w-32" />
-            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
-              {[1, 2, 3].map((i) => (
-                <div
-                  key={i}
-                  className="flex items-center gap-3 p-3 rounded-lg border"
-                >
-                  <Skeleton className="h-10 w-10 rounded-full" />
-                  <div className="space-y-2 flex-1">
-                    <Skeleton className="h-4 w-24" />
-                    <Skeleton className="h-3 w-16" />
-                  </div>
-                </div>
-              ))}
-            </div>
-          </div>
-        </CardContent>
-      </Card>
+    <div
+      className="min-h-screen w-full flex items-center justify-center select-none"
+      style={{
+        backgroundColor: "var(--brand-cream)",
+        color: "var(--brand-muted)",
+      }}
+    >
+      <span className="font-serif text-lg tracking-wide lowercase">
+        fetching latest...
+      </span>
     </div>
   );
 }
+

--- a/app/src/app/[slug]/project-details.tsx
+++ b/app/src/app/[slug]/project-details.tsx
@@ -1,38 +1,108 @@
 "use client";
-import { useRouter } from "next/navigation";
+
+import { useState } from "react";
+import Link from "next/link";
 import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-} from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import {
-  ArrowLeft,
-  Calendar,
-  Code2,
-  ExternalLink,
-  GitFork,
-  Heart,
-  Star,
-  Users,
-} from "lucide-react";
-import { motion } from "framer-motion";
+  motion,
+  useReducedMotion,
+  type Variants,
+} from "framer-motion";
+import { Cursor } from "@/components/Cursor";
 import type { Contributor, Repo } from "@/lib/fetchRepos";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
-import { Progress } from "@/components/ui/progress";
-import {
-  HoverCard,
-  HoverCardContent,
-  HoverCardTrigger,
-} from "@/components/ui/hover-card";
+
+// ─── Motion constants (matching landing/CV/projects pages) ──────────────────
+
+const expo = [0.16, 1, 0.3, 1] as [number, number, number, number];
+const spring = { type: "spring" as const, stiffness: 100, damping: 22 };
+
+const containerVariants: Variants = {
+  hidden: {},
+  visible: {
+    transition: { staggerChildren: 0.12, delayChildren: 0.08 },
+  },
+};
+
+const navVariants: Variants = {
+  hidden: { y: -100 },
+  visible: {
+    y: 0,
+    transition: { ...spring, staggerChildren: 0.1 },
+  },
+};
+
+const fadeUp: Variants = {
+  hidden: { opacity: 0, y: 20 },
+  visible: { opacity: 1, y: 0, transition: { duration: 0.9, ease: expo } },
+};
+
+// ─── Shared UnderlineLink ───────────────────────────────────────────────────
+
+interface UnderlineLinkProps {
+  href?: string;
+  onClick?: () => void;
+  children: React.ReactNode;
+  className?: string;
+}
+
+function UnderlineLink({
+  href,
+  onClick,
+  children,
+  className = "",
+}: UnderlineLinkProps) {
+  const base =
+    "group relative inline-flex items-center text-sm tracking-wide " +
+    "text-[var(--brand-muted)] hover:text-[var(--brand-ink)] transition-colors duration-200 " +
+    "rounded-sm focus-visible:outline-none focus-visible:ring-2 " +
+    "focus-visible:ring-[var(--brand-ink)] focus-visible:ring-offset-2 " +
+    "bg-transparent border-none p-0 cursor-pointer " +
+    className;
+
+  const underline = (
+    <span
+      aria-hidden
+      className="absolute -bottom-0.5 left-0 h-px w-0 bg-[var(--brand-ink)] transition-[width] duration-300 ease-out group-hover:w-full group-focus-visible:w-full"
+    />
+  );
+
+  if (onClick) {
+    return (
+      <button onClick={onClick} data-cursor="link" className={base}>
+        {children}
+        {underline}
+      </button>
+    );
+  }
+
+  if (!href) return null;
+
+  const isExternal = href.startsWith("http") || href.startsWith("//");
+  const isMail = href.startsWith("mailto:");
+
+  if (isExternal || isMail) {
+    return (
+      <a
+        href={href}
+        target={isMail ? undefined : "_blank"}
+        rel={isMail ? undefined : "noopener noreferrer"}
+        data-cursor="link"
+        className={base}
+      >
+        {children}
+        {underline}
+      </a>
+    );
+  }
+
+  return (
+    <Link href={href} data-cursor="link" className={base}>
+      {children}
+      {underline}
+    </Link>
+  );
+}
+
+// ─── ProjectDetailsClient ───────────────────────────────────────────────────
 
 interface ProjectDetailsClientProps {
   repo: Repo;
@@ -40,27 +110,15 @@ interface ProjectDetailsClientProps {
   contributors: Contributor[];
 }
 
-const fadeIn = {
-  initial: { opacity: 0, y: 20 },
-  animate: { opacity: 1, y: 0 },
-  transition: { duration: 0.5 },
-};
-
-const staggerChildren = {
-  animate: {
-    transition: {
-      staggerChildren: 0.1,
-    },
-  },
-};
-
 export function ProjectDetailsClient({
   repo,
   languages,
   contributors,
 }: ProjectDetailsClientProps) {
-  const router = useRouter();
-  const totalBytes = Object.values(languages).reduce((a, b) => a + b, 0);
+  const [cursorEnabled, setCursorEnabled] = useState(false);
+  const shouldReduce = useReducedMotion();
+
+  const totalBytes = Object.values(languages).reduce((a, b) => a + b, 0) || 1;
   const lastUpdated = new Date(repo.updated_at).toLocaleDateString("en-US", {
     year: "numeric",
     month: "long",
@@ -68,225 +126,271 @@ export function ProjectDetailsClient({
   });
 
   return (
-    <div className="container mx-auto px-4 py-6 md:py-10 space-y-6 md:space-y-8 select-none">
-      <motion.div className="flex flex-col gap-4" {...fadeIn}>
-        <div className="flex flex-col gap-2">
-          <div className="flex justify-between items-center">
-            <Button
-              variant="ghost"
-              onClick={() => router.push("/projects")}
-              className="flex items-center gap-2"
-            >
-              <ArrowLeft className="h-4 w-4" />
-              Back to Projects
-            </Button>
-            <Button
-              onClick={() => router.push("/donate")}
-              variant="default"
-              className="flex items-center gap-2"
-            >
-              <Heart className="h-4 w-4" />
-              Donate
-            </Button>
-          </div>
-          <h1 className="text-3xl md:text-4xl font-bold tracking-tight">
-            {repo.name}
-          </h1>
+    <main
+      className={`relative min-h-screen w-full overflow-x-hidden${
+        cursorEnabled ? " cursor-none" : ""
+      }`}
+      style={{
+        backgroundColor: "var(--brand-cream)",
+        color: "var(--brand-ink)",
+      }}
+    >
+      <Cursor onEnable={setCursorEnabled} />
+
+      {/* ── Nav ──────────────────────────────────────────────────────── */}
+      <motion.nav
+        aria-label="primary navigation"
+        className="fixed left-0 right-0 top-0 z-50 flex flex-wrap items-center justify-between px-6 py-4 md:px-10 md:py-5 select-none"
+        style={{
+          backgroundColor: "rgba(243, 241, 234, 0.85)",
+          backdropFilter: "blur(12px)",
+          WebkitBackdropFilter: "blur(12px)",
+          willChange: "transform",
+        }}
+        initial={shouldReduce ? "visible" : "hidden"}
+        animate="visible"
+        variants={navVariants}
+      >
+        <div className="flex items-center gap-4">
+          <Link
+            href="/"
+            data-cursor="link"
+            className="text-sm font-medium tracking-tight focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-ink)] focus-visible:ring-offset-2 rounded-sm"
+            style={{ color: "var(--brand-ink)" }}
+          >
+            Doğukan Ürker
+          </Link>
+          <span
+            className="hidden items-center gap-1 text-sm md:inline-flex"
+            style={{ color: "var(--brand-muted)" }}
+          >
+            <span>full-stack engineer @</span>
+            <UnderlineLink href="https://sensity.ai">sensity.ai</UnderlineLink>
+          </span>
         </div>
-      </motion.div>
+        <div className="flex items-center gap-6">
+          <UnderlineLink href="/">home</UnderlineLink>
+          <UnderlineLink href="/cv">resume</UnderlineLink>
+        </div>
+        {/* mobile role subtitle on a second row */}
+        <div
+          className="mt-1 flex w-full items-center gap-1 text-xs leading-relaxed tracking-wide md:hidden"
+          style={{ color: "var(--brand-muted)" }}
+        >
+          <span>full-stack engineer @</span>
+          <UnderlineLink href="https://sensity.ai" className="text-xs">
+            sensity.ai
+          </UnderlineLink>
+        </div>
+      </motion.nav>
 
-      <motion.div {...fadeIn} transition={{ duration: 0.5, delay: 0.2 }}>
-        <Card className="overflow-hidden">
-          <CardHeader className="space-y-4">
-            <div className="flex justify-between items-start">
-              <CardDescription className="text-base md:text-lg">
-                {repo.description}
-              </CardDescription>
-              {repo.license && (
-                <Badge
-                  variant="secondary"
-                  className="text-sm ml-4 hover:scale-110 transition-transform cursor-pointer"
-                  onClick={() =>
-                    window.open(`${repo.html_url}/blob/main/LICENSE`, "_blank")
-                  }
-                >
-                  {repo.license.spdx_id}
-                </Badge>
-              )}
-            </div>
-            <div className="flex flex-wrap gap-2">
-              <Button variant="outline" asChild>
-                <a
-                  href={repo.html_url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="flex items-center gap-2"
-                >
-                  View on GitHub
-                  <ExternalLink className="h-4 w-4" />
-                </a>
-              </Button>
-            </div>
-          </CardHeader>
-          <CardContent className="space-y-8">
-            <motion.div
-              className="grid grid-cols-2 md:grid-cols-3 gap-4"
-              variants={staggerChildren}
+      {/* ── Content ──────────────────────────────────────────────────── */}
+      <div className="mx-auto max-w-2xl px-6 pb-[calc(5rem+env(safe-area-inset-bottom))] pt-32 sm:px-10 sm:pt-40">
+        <motion.div
+          initial={shouldReduce ? "visible" : "hidden"}
+          animate="visible"
+          variants={containerVariants}
+          className="flex flex-col gap-12"
+        >
+          {/* Back & Donate Actions */}
+          <motion.div variants={fadeUp} className="flex justify-between items-center">
+            <UnderlineLink href="/projects">
+              back to projects
+            </UnderlineLink>
+            <UnderlineLink href="/donate">
+              support
+            </UnderlineLink>
+          </motion.div>
+
+          {/* Header */}
+          <motion.header variants={fadeUp} className="space-y-4">
+            <h1
+              className="font-serif tracking-tighter lowercase"
+              style={{
+                fontSize: "clamp(44px, 10vw, 84px)",
+                fontWeight: 400,
+                lineHeight: 0.95,
+                color: "var(--brand-ink)",
+                fontOpticalSizing: "auto",
+                margin: 0,
+              }}
             >
-              <Card
-                className="p-3 md:p-4 hover:scale-[1.02] transition-transform cursor-pointer"
-                onClick={() =>
-                  window.open(`${repo.html_url}/stargazers`, "_blank")
-                }
+              {repo.name.toLowerCase()}
+            </h1>
+            {repo.description && (
+              <p
+                className="font-serif lowercase"
+                style={{
+                  fontSize: "clamp(18px, 2.5vw, 24px)",
+                  lineHeight: 1.3,
+                  fontWeight: 340,
+                  color: "var(--brand-muted)",
+                  fontOpticalSizing: "auto",
+                  maxWidth: "32ch",
+                  margin: "1.5rem 0 0 0",
+                }}
               >
-                <div className="flex items-center gap-2">
-                  <Star className="h-4 w-4 md:h-5 md:w-5 text-muted-foreground" />
-                  <div className="font-semibold">{repo.stargazers_count}</div>
-                  <div className="text-muted-foreground text-sm">Stars</div>
-                </div>
-              </Card>
-              <Card
-                className="p-3 md:p-4 hover:scale-[1.02] transition-transform cursor-pointer"
-                onClick={() => window.open(`${repo.html_url}/forks`, "_blank")}
-              >
-                <div className="flex items-center gap-2">
-                  <GitFork className="h-4 w-4 md:h-5 md:w-5 text-muted-foreground" />
-                  <div className="font-semibold">{repo.forks}</div>
-                  <div className="text-muted-foreground text-sm">Forks</div>
-                </div>
-              </Card>
-              <Card
-                className="p-3 md:p-4 col-span-2 md:col-span-1 hover:scale-[1.02] transition-transform cursor-pointer"
-                onClick={() =>
-                  window.open(`${repo.html_url}/commits`, "_blank")
-                }
-              >
-                <div className="flex items-center gap-2">
-                  <Calendar className="h-4 w-4 md:h-5 md:w-5 text-muted-foreground" />
-                  <div className="text-sm text-muted-foreground truncate">
-                    Updated: {lastUpdated}
-                  </div>
-                </div>
-              </Card>
-            </motion.div>
-
-            {contributors.length > 0 && (
-              <div className="space-y-4">
-                <div className="flex items-center gap-2">
-                  <Users className="h-5 w-5" />
-                  <h3 className="font-semibold text-lg">Contributors</h3>
-                </div>
-                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
-                  {contributors.map((contributor) => (
-                    <motion.div
-                      key={contributor.login}
-                      className="flex items-center gap-3 p-3 rounded-lg border bg-card hover:scale-110 transition-transform cursor-pointer"
-                      onClick={() =>
-                        window.open(
-                          `${repo.html_url}/commits?author=${contributor.login}`,
-                          "_blank",
-                        )
-                      }
-                      whileHover={{ scale: 1.02 }}
-                      initial={{ opacity: 0, y: 20 }}
-                      animate={{ opacity: 1, y: 0 }}
-                    >
-                      <TooltipProvider>
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <Avatar
-                              className="cursor-pointer h-8 w-8 md:h-10 md:w-10"
-                              onClick={() =>
-                                window.open(contributor.html_url, "_blank")
-                              }
-                            >
-                              <AvatarImage
-                                src={contributor.avatar_url}
-                                alt={contributor.login}
-                              />
-                              <AvatarFallback>
-                                {contributor.login[0]}
-                              </AvatarFallback>
-                            </Avatar>
-                          </TooltipTrigger>
-                          <TooltipContent>
-                            {contributor.login}
-                            <br />
-                            {contributor.contributions} contributions
-                          </TooltipContent>
-                        </Tooltip>
-                      </TooltipProvider>
-                      <div className="flex flex-col min-w-0">
-                        <span className="font-medium truncate">
-                          {contributor.login}
-                        </span>
-                        <span className="text-sm text-muted-foreground">
-                          {contributor.contributions} commits
-                        </span>
-                      </div>
-                    </motion.div>
-                  ))}
-                </div>
-              </div>
+                {repo.description.toLowerCase()}
+              </p>
             )}
+          </motion.header>
 
-            <div className="space-y-4">
-              <div className="flex items-center gap-2">
-                <Code2 className="h-5 w-5" />
-                <h3 className="font-semibold text-lg">Languages</h3>
+          {/* Repo Info Grid */}
+          <motion.section variants={fadeUp} className="space-y-6">
+            <hr style={{ border: "none", borderTop: "1px solid var(--brand-border)", margin: 0 }} />
+            <dl className="grid grid-cols-[120px_1fr] gap-x-8 gap-y-3">
+              <div className="contents">
+                <dt className="text-sm tracking-wide lowercase" style={{ color: "var(--brand-dim)" }}>
+                  repository
+                </dt>
+                <dd className="text-sm lowercase">
+                  <UnderlineLink href={repo.html_url}>
+                    view on github ↗
+                  </UnderlineLink>
+                </dd>
               </div>
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div className="contents">
+                <dt className="text-sm tracking-wide lowercase" style={{ color: "var(--brand-dim)" }}>
+                  stars
+                </dt>
+                <dd className="text-sm lowercase" style={{ color: "var(--brand-ink)" }}>
+                  {repo.stargazers_count}
+                </dd>
+              </div>
+              <div className="contents">
+                <dt className="text-sm tracking-wide lowercase" style={{ color: "var(--brand-dim)" }}>
+                  forks
+                </dt>
+                <dd className="text-sm lowercase" style={{ color: "var(--brand-ink)" }}>
+                  {repo.forks}
+                </dd>
+              </div>
+              <div className="contents">
+                <dt className="text-sm tracking-wide lowercase" style={{ color: "var(--brand-dim)" }}>
+                  license
+                </dt>
+                <dd className="text-sm lowercase" style={{ color: "var(--brand-ink)" }}>
+                  {repo.license ? repo.license.spdx_id.toLowerCase() : "none"}
+                </dd>
+              </div>
+              <div className="contents">
+                <dt className="text-sm tracking-wide lowercase" style={{ color: "var(--brand-dim)" }}>
+                  updated
+                </dt>
+                <dd className="text-sm lowercase" style={{ color: "var(--brand-ink)" }}>
+                  {lastUpdated.toLowerCase()}
+                </dd>
+              </div>
+            </dl>
+          </motion.section>
+
+          {/* Languages Section */}
+          {Object.keys(languages).length > 0 && (
+            <motion.section variants={fadeUp} className="space-y-6">
+              <hr style={{ border: "none", borderTop: "1px solid var(--brand-border)", margin: 0 }} />
+              <h2
+                className="font-serif lowercase"
+                style={{
+                  fontSize: "clamp(22px, 3.4vw, 30px)",
+                  fontWeight: 420,
+                  lineHeight: 1.1,
+                  color: "var(--brand-ink)",
+                  fontOpticalSizing: "auto",
+                  margin: 0,
+                }}
+              >
+                languages
+              </h2>
+              <dl className="grid grid-cols-[120px_1fr] gap-x-8 gap-y-3">
                 {Object.entries(languages)
                   .sort(([, a], [, b]) => b - a)
                   .map(([lang, bytes]) => {
                     const percentage = ((bytes / totalBytes) * 100).toFixed(1);
                     return (
-                      <motion.div
-                        key={lang}
-                        initial={{ opacity: 0, y: 20 }}
-                        animate={{ opacity: 1, y: 0 }}
-                        whileHover={{ scale: 1.02 }}
-                      >
-                        <HoverCard>
-                          <HoverCardTrigger asChild>
-                            <Card className="p-4">
-                              <div className="space-y-3">
-                                <div className="flex justify-between items-center">
-                                  <span className="font-medium">{lang}</span>
-                                  <Badge variant="secondary">
-                                    {percentage}%
-                                  </Badge>
-                                </div>
-                                <Progress
-                                  value={parseFloat(percentage)}
-                                  className="h-2"
-                                />
-                                <div className="text-sm text-muted-foreground">
-                                  {(bytes / 1024).toFixed(1)} KB
-                                </div>
-                              </div>
-                            </Card>
-                          </HoverCardTrigger>
-                          <HoverCardContent className="w-80 hidden">
-                            <div className="space-y-2">
-                              <h4 className="font-semibold">
-                                {lang} Usage Statistics
-                              </h4>
-                              <div className="text-sm text-muted-foreground">
-                                <p>Total bytes: {bytes.toLocaleString()}</p>
-                                <p>Percentage of codebase: {percentage}%</p>
-                              </div>
-                            </div>
-                          </HoverCardContent>
-                        </HoverCard>
-                      </motion.div>
+                      <div key={lang} className="contents">
+                        <dt className="text-sm tracking-wide lowercase" style={{ color: "var(--brand-dim)" }}>
+                          {lang.toLowerCase()}
+                        </dt>
+                        <dd className="text-sm lowercase" style={{ color: "var(--brand-muted)" }}>
+                          {percentage}% <span className="text-[var(--brand-dim)]">({(bytes / 1024).toFixed(1)} kb)</span>
+                        </dd>
+                      </div>
                     );
                   })}
+              </dl>
+            </motion.section>
+          )}
+
+          {/* Contributors Section */}
+          {contributors.length > 0 && (
+            <motion.section variants={fadeUp} className="space-y-6">
+              <hr style={{ border: "none", borderTop: "1px solid var(--brand-border)", margin: 0 }} />
+              <h2
+                className="font-serif lowercase"
+                style={{
+                  fontSize: "clamp(22px, 3.4vw, 30px)",
+                  fontWeight: 420,
+                  lineHeight: 1.1,
+                  color: "var(--brand-ink)",
+                  fontOpticalSizing: "auto",
+                  margin: 0,
+                }}
+              >
+                contributors
+              </h2>
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
+                {contributors.map((contributor) => (
+                  <a
+                    key={contributor.login}
+                    href={contributor.html_url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    data-cursor="link"
+                    className="flex items-center gap-3 text-sm text-[var(--brand-muted)] hover:text-[var(--brand-ink)] transition-colors group"
+                  >
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                      src={contributor.avatar_url}
+                      alt={contributor.login}
+                      className="w-8 h-8 rounded-full grayscale transition-[filter,transform] duration-300 group-hover:grayscale-0 group-hover:scale-105 border border-[var(--brand-border)]"
+                    />
+                    <div className="flex flex-col min-w-0">
+                      <span className="font-medium tracking-tight lowercase text-[var(--brand-ink)] truncate">
+                        {contributor.login.toLowerCase()}
+                      </span>
+                      <span className="text-xs lowercase text-[var(--brand-dim)]">
+                        {contributor.contributions} {contributor.contributions === 1 ? "commit" : "commits"}
+                      </span>
+                    </div>
+                  </a>
+                ))}
               </div>
-            </div>
-          </CardContent>
-        </Card>
-      </motion.div>
-    </div>
+            </motion.section>
+          )}
+        </motion.div>
+      </div>
+
+      {/* ── Footer ───────────────────────────────────────────────────── */}
+      <footer
+        className="flex flex-col items-center gap-3 px-6 pb-[calc(3rem+env(safe-area-inset-bottom))] select-none sm:flex-row sm:items-center sm:justify-between sm:px-10 sm:pb-10"
+        style={{ color: "var(--brand-muted)" }}
+      >
+        <span className="text-sm lowercase">izmir, türkiye</span>
+        <nav aria-label="social links" className="flex items-center gap-5">
+          <UnderlineLink href="mailto:dogukanurker@icloud.com">
+            mail
+          </UnderlineLink>
+          <UnderlineLink href="https://github.com/dogukanurker">
+            github
+          </UnderlineLink>
+          <UnderlineLink href="https://twitter.com/dogukanurker">
+            twitter
+          </UnderlineLink>
+          <UnderlineLink href="https://linkedin.com/in/dogukanurker">
+            linkedin
+          </UnderlineLink>
+        </nav>
+      </footer>
+    </main>
   );
 }

--- a/app/src/app/projects/loading.tsx
+++ b/app/src/app/projects/loading.tsx
@@ -1,38 +1,16 @@
-import {
-  Card,
-  CardContent,
-  CardFooter,
-  CardHeader,
-} from "@/components/ui/card";
-import { Skeleton } from "@/components/ui/skeleton";
-
 export default function Loading() {
   return (
-    <div className="container mx-auto py-10">
-      <h1 className="text-4xl font-bold mb-8">Projects</h1>
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-        {Array.from({ length: 6 }).map((_, index) => (
-          <Card
-            key={index}
-            className="group animate-in fade-in-50 duration-1000 hover:shadow-lg transition-all duration-300 hover:-translate-y-1"
-          >
-            <CardHeader>
-              <Skeleton className="h-8 w-3/4 mb-2" />
-              <Skeleton className="h-4 w-full mb-1" />
-              <Skeleton className="h-4 w-2/3" />
-            </CardHeader>
-            <CardContent>
-              <div className="flex gap-4">
-                <Skeleton className="h-6 w-16" />
-                <Skeleton className="h-6 w-16" />
-              </div>
-            </CardContent>
-            <CardFooter>
-              <Skeleton className="h-10 w-full" />
-            </CardFooter>
-          </Card>
-        ))}
-      </div>
+    <div
+      className="min-h-screen w-full flex items-center justify-center select-none"
+      style={{
+        backgroundColor: "var(--brand-cream)",
+        color: "var(--brand-muted)",
+      }}
+    >
+      <span className="font-serif text-lg tracking-wide lowercase">
+        fetching latest...
+      </span>
     </div>
   );
 }
+

--- a/app/src/app/projects/page.tsx
+++ b/app/src/app/projects/page.tsx
@@ -1,16 +1,5 @@
 import { fetchRepos } from "@/lib/fetchRepos";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
-import { ArrowRight, GitFork, Star } from "lucide-react";
-import Link from "next/link";
+import { ProjectsClient } from "./projects-client";
 
 export default async function Projects() {
   const repos = await fetchRepos(
@@ -18,59 +7,6 @@ export default async function Projects() {
     process.env.GITHUB_API_KEY ?? "",
   );
 
-  return (
-    <div className="container mx-auto py-10">
-      <h1 className="text-4xl font-bold mb-8">Projects</h1>
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-        {repos.map((repo) => (
-          <Card
-            key={repo.id}
-            className="group animate-in fade-in-50 duration-1000 hover:shadow-lg transition-all duration-300 hover:-translate-y-1"
-          >
-            <CardHeader>
-              <CardTitle className="text-2xl font-bold tracking-tight">
-                {repo.name}
-              </CardTitle>
-              <CardDescription className="line-clamp-2 h-12">
-                {repo.description || "No description available"}
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <div className="flex gap-4">
-                <Badge
-                  variant="secondary"
-                  className="flex items-center gap-1"
-                >
-                  <GitFork className="h-4 w-4" />
-                  {repo.forks}
-                </Badge>
-                <Badge
-                  variant="secondary"
-                  className="flex items-center gap-1"
-                >
-                  <Star className="h-4 w-4" />
-                  {repo.stargazers_count}
-                </Badge>
-              </div>
-            </CardContent>
-            <CardFooter>
-              <Button
-                variant="outline"
-                className="w-full group-hover:bg-primary group-hover:text-primary-foreground transition-colors"
-                asChild
-              >
-                <Link
-                  href={`/${repo.name}`}
-                  className="flex items-center justify-between"
-                >
-                  View Project
-                  <ArrowRight className="h-4 w-4" />
-                </Link>
-              </Button>
-            </CardFooter>
-          </Card>
-        ))}
-      </div>
-    </div>
-  );
+  return <ProjectsClient repos={repos} />;
 }
+

--- a/app/src/app/projects/projects-client.tsx
+++ b/app/src/app/projects/projects-client.tsx
@@ -1,0 +1,295 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import {
+  motion,
+  useReducedMotion,
+  type Variants,
+} from "framer-motion";
+import { Cursor } from "@/components/Cursor";
+import type { Repo } from "@/lib/fetchRepos";
+
+// ─── Motion constants (matching landing/CV pages) ──────────────────────────
+
+const expo = [0.16, 1, 0.3, 1] as [number, number, number, number];
+const spring = { type: "spring" as const, stiffness: 100, damping: 22 };
+
+const containerVariants: Variants = {
+  hidden: {},
+  visible: {
+    transition: { staggerChildren: 0.12, delayChildren: 0.08 },
+  },
+};
+
+const navVariants: Variants = {
+  hidden: { y: -100 },
+  visible: {
+    y: 0,
+    transition: { ...spring, staggerChildren: 0.1 },
+  },
+};
+
+const fadeUp: Variants = {
+  hidden: { opacity: 0, y: 20 },
+  visible: { opacity: 1, y: 0, transition: { duration: 0.9, ease: expo } },
+};
+
+// ─── Shared UnderlineLink ───────────────────────────────────────────────────
+
+interface UnderlineLinkProps {
+  href?: string;
+  onClick?: () => void;
+  children: React.ReactNode;
+  className?: string;
+}
+
+function UnderlineLink({
+  href,
+  onClick,
+  children,
+  className = "",
+}: UnderlineLinkProps) {
+  const base =
+    "group relative inline-flex items-center text-sm tracking-wide " +
+    "text-[var(--brand-muted)] hover:text-[var(--brand-ink)] transition-colors duration-200 " +
+    "rounded-sm focus-visible:outline-none focus-visible:ring-2 " +
+    "focus-visible:ring-[var(--brand-ink)] focus-visible:ring-offset-2 " +
+    "bg-transparent border-none p-0 cursor-pointer " +
+    className;
+
+  const underline = (
+    <span
+      aria-hidden
+      className="absolute -bottom-0.5 left-0 h-px w-0 bg-[var(--brand-ink)] transition-[width] duration-300 ease-out group-hover:w-full group-focus-visible:w-full"
+    />
+  );
+
+  if (onClick) {
+    return (
+      <button onClick={onClick} data-cursor="link" className={base}>
+        {children}
+        {underline}
+      </button>
+    );
+  }
+
+  if (!href) return null;
+
+  const isExternal = href.startsWith("http") || href.startsWith("//");
+  const isMail = href.startsWith("mailto:");
+
+  if (isExternal || isMail) {
+    return (
+      <a
+        href={href}
+        target={isMail ? undefined : "_blank"}
+        rel={isMail ? undefined : "noopener noreferrer"}
+        data-cursor="link"
+        className={base}
+      >
+        {children}
+        {underline}
+      </a>
+    );
+  }
+
+  return (
+    <Link href={href} data-cursor="link" className={base}>
+      {children}
+      {underline}
+    </Link>
+  );
+}
+
+
+// ─── ProjectsClient ─────────────────────────────────────────────────────────
+
+interface ProjectsClientProps {
+  repos: Repo[];
+}
+
+export function ProjectsClient({ repos }: ProjectsClientProps) {
+  const [cursorEnabled, setCursorEnabled] = useState(false);
+  const shouldReduce = useReducedMotion();
+
+  const totalStars = repos.reduce((acc, repo) => acc + repo.stargazers_count, 0);
+  const totalForks = repos.reduce((acc, repo) => acc + repo.forks, 0);
+
+  return (
+    <main
+      className={`relative min-h-screen w-full overflow-x-hidden${
+        cursorEnabled ? " cursor-none" : ""
+      }`}
+      style={{
+        backgroundColor: "var(--brand-cream)",
+        color: "var(--brand-ink)",
+      }}
+    >
+      <Cursor onEnable={setCursorEnabled} />
+
+      {/* ── Nav ──────────────────────────────────────────────────────── */}
+      <motion.nav
+        aria-label="primary navigation"
+        className="fixed left-0 right-0 top-0 z-50 flex flex-wrap items-center justify-between px-6 py-4 md:px-10 md:py-5 select-none"
+        style={{
+          backgroundColor: "rgba(243, 241, 234, 0.85)",
+          backdropFilter: "blur(12px)",
+          WebkitBackdropFilter: "blur(12px)",
+          willChange: "transform",
+        }}
+        initial={shouldReduce ? "visible" : "hidden"}
+        animate="visible"
+        variants={navVariants}
+      >
+        <div className="flex items-center gap-4">
+          <Link
+            href="/"
+            data-cursor="link"
+            className="text-sm font-medium tracking-tight focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-ink)] focus-visible:ring-offset-2 rounded-sm"
+            style={{ color: "var(--brand-ink)" }}
+          >
+            Doğukan Ürker
+          </Link>
+          <span
+            className="hidden items-center gap-1 text-sm md:inline-flex"
+            style={{ color: "var(--brand-muted)" }}
+          >
+            <span>full-stack engineer @</span>
+            <UnderlineLink href="https://sensity.ai">sensity.ai</UnderlineLink>
+          </span>
+        </div>
+        <div className="flex items-center gap-6">
+          <UnderlineLink href="/">home</UnderlineLink>
+          <UnderlineLink href="/cv">resume</UnderlineLink>
+        </div>
+        {/* mobile role subtitle on a second row */}
+        <div
+          className="mt-1 flex w-full items-center gap-1 text-xs leading-relaxed tracking-wide md:hidden"
+          style={{ color: "var(--brand-muted)" }}
+        >
+          <span>full-stack engineer @</span>
+          <UnderlineLink href="https://sensity.ai" className="text-xs">
+            sensity.ai
+          </UnderlineLink>
+        </div>
+      </motion.nav>
+
+      {/* ── Content ──────────────────────────────────────────────────── */}
+      <div className="mx-auto max-w-2xl px-6 pb-[calc(5rem+env(safe-area-inset-bottom))] pt-32 sm:px-10 sm:pt-40">
+        <motion.header
+          initial={shouldReduce ? "visible" : "hidden"}
+          animate="visible"
+          variants={containerVariants}
+        >
+          <motion.h1
+            variants={fadeUp}
+            className="font-serif tracking-tighter lowercase"
+            style={{
+              fontSize: "clamp(40px, 11vw, 92px)",
+              fontWeight: 400,
+              lineHeight: 0.95,
+              color: "var(--brand-ink)",
+              fontOpticalSizing: "auto",
+              margin: 0,
+            }}
+          >
+            projects
+          </motion.h1>
+          <motion.p
+            variants={fadeUp}
+            className="mt-6 text-sm tracking-wide lowercase"
+            style={{ color: "var(--brand-muted)" }}
+          >
+            a collection of open-source work &mdash; {totalStars} stars and {totalForks} forks across all repositories, with more than 60k downloads overall
+          </motion.p>
+        </motion.header>
+
+        {/* ── Projects List ────────────────────────────────────────────── */}
+        <div className="mt-14 flex flex-col gap-14">
+          <motion.div
+            className="flex flex-col gap-10"
+            initial={shouldReduce ? "visible" : "hidden"}
+            animate="visible"
+            variants={containerVariants}
+          >
+            {repos.map((repo) => (
+              <motion.div
+                key={repo.id}
+                variants={fadeUp}
+                className="group"
+              >
+                <hr
+                  style={{
+                    border: "none",
+                    borderTop: "1px solid var(--brand-border)",
+                    margin: "0 0 28px",
+                  }}
+                />
+                <div className="flex flex-col gap-1 sm:flex-row sm:items-baseline sm:justify-between sm:gap-6">
+                  <div className="min-w-0">
+                    <h2 className="text-base font-medium tracking-tight">
+                      <UnderlineLink href={`/${repo.name.toLowerCase()}`}>
+                        <span style={{ color: "var(--brand-ink)" }}>
+                          {repo.name.toLowerCase()}
+                        </span>
+                      </UnderlineLink>
+                    </h2>
+                    {repo.language && (
+                      <p className="text-xs mt-1 lowercase" style={{ color: "var(--brand-dim)" }}>
+                        {repo.language.toLowerCase()}
+                      </p>
+                    )}
+                  </div>
+                  <div className="shrink-0 text-sm tracking-wide sm:text-right mt-1 sm:mt-0 lowercase" style={{ color: "var(--brand-dim)" }}>
+                    <span>
+                      {repo.stargazers_count} {repo.stargazers_count === 1 ? "star" : "stars"}
+                    </span>
+                    <span className="mx-2 select-none">&middot;</span>
+                    <span>
+                      {repo.forks} {repo.forks === 1 ? "fork" : "forks"}
+                    </span>
+                  </div>
+                </div>
+                {repo.description && (
+                  <p
+                    className="mt-3 text-sm lowercase"
+                    style={{
+                      color: "var(--brand-muted)",
+                      lineHeight: 1.65,
+                      maxWidth: "62ch",
+                    }}
+                  >
+                    {repo.description.toLowerCase()}
+                  </p>
+                )}
+              </motion.div>
+            ))}
+          </motion.div>
+        </div>
+      </div>
+
+      {/* ── Footer ───────────────────────────────────────────────────── */}
+      <footer
+        className="flex flex-col items-center gap-3 px-6 pb-[calc(3rem+env(safe-area-inset-bottom))] select-none sm:flex-row sm:items-center sm:justify-between sm:px-10 sm:pb-10"
+        style={{ color: "var(--brand-muted)" }}
+      >
+        <span className="text-sm lowercase">izmir, türkiye</span>
+        <nav aria-label="social links" className="flex items-center gap-5">
+          <UnderlineLink href="mailto:dogukanurker@icloud.com">
+            mail
+          </UnderlineLink>
+          <UnderlineLink href="https://github.com/dogukanurker">
+            github
+          </UnderlineLink>
+          <UnderlineLink href="https://twitter.com/dogukanurker">
+            twitter
+          </UnderlineLink>
+          <UnderlineLink href="https://linkedin.com/in/dogukanurker">
+            linkedin
+          </UnderlineLink>
+        </nav>
+      </footer>
+    </main>
+  );
+}

--- a/app/src/lib/fetchRepos.ts
+++ b/app/src/lib/fetchRepos.ts
@@ -38,12 +38,10 @@ export async function fetchRepos(
   );
   const json: unknown = await response.json();
   if (!Array.isArray(json)) return [];
-  let data: Repo[] = (json as Repo[])
-    .sort((a: Repo, b: Repo) => b.stargazers_count - a.stargazers_count)
-    .sort(
-      (a: Repo, b: Repo) =>
-        new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime(),
-    );
+  let data: Repo[] = (json as Repo[]).sort(
+    (a: Repo, b: Repo) => b.stargazers_count - a.stargazers_count,
+  );
+
 
   const flaskArticleRepo = data.find((repo) => repo.id === 566979145);
   if (flaskArticleRepo) {


### PR DESCRIPTION
This pull request redesigns the /projects listing page and the dynamic /[slug] project details page to match the quiet, typographic, cream-and-ink aesthetic specified in docs/design.md. Skeletons and progress bar dashboard elements have been removed in favor of pure typography, lists, and metadata grids.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added motion-based animations and cursor-aware interactions to project pages for enhanced visual experience.
  * Improved responsive layout on project details and listings.

* **Style**
  * Simplified loading indicators with cleaner, minimal design.
  * Updated typography and link styling across project pages.

* **Refactor**
  * Reorganized project details page with improved layout structure.
  * Refined repository sorting logic for better ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->