### PR TITLE
feat: add instagram to cv contacts and footer

### DIFF
--- a/app/src/app/cv/page.tsx
+++ b/app/src/app/cv/page.tsx
@@ -751,6 +751,9 @@ export default function CVPage() {
           <UnderlineLink href="https://linkedin.com/in/dogukanurker">
             linkedin
           </UnderlineLink>
+          <UnderlineLink href="https://instagram.com/dogukanurker">
+            instagram
+          </UnderlineLink>
         </nav>
       </footer>
     </main>

--- a/app/src/lib/cv.ts
+++ b/app/src/lib/cv.ts
@@ -210,6 +210,10 @@ export const contacts = [
     label: "linkedin.com/in/dogukanurker",
     href: "https://linkedin.com/in/dogukanurker",
   },
+  {
+    label: "instagram.com/dogukanurker",
+    href: "https://instagram.com/dogukanurker",
+  },
 ];
 
 // ─── GitHub stats ───────────────────────────────────────────────────────────


### PR DESCRIPTION
This PR adds the Instagram social link to both the CV contact list and the footer section of the /cv page.